### PR TITLE
fix: vant-theme2 theme list keeps in sync with the modified value

### DIFF
--- a/src/page/theme/App.vue
+++ b/src/page/theme/App.vue
@@ -17,7 +17,7 @@ import useMainStore from "@/stores";
 import { APP_BASE_URL, APP_HEADER_LINKS } from "@/utils/constant";
 import type { VersionInfo } from "@/utils/type";
 import LayoutProvider from "@/components/LayoutProvider.vue";
-import ThemeView from "./theme.vue";
+import ThemeView from "./ThemeView.vue";
 
 const $store = useMainStore();
 

--- a/src/page/theme/ThemeView.vue
+++ b/src/page/theme/ThemeView.vue
@@ -191,16 +191,23 @@ import {
   V3_MAIN_COLOR,
   V4_MAIN_COLOR,
 } from "@/utils/constant";
-import type { DefauleColor, Theme, Color, ModalValue } from "@/utils/type";
+import type {
+  DefauleColor,
+  Theme,
+  Color,
+  ModalValue,
+  V2Color,
+  V2DefauleColor,
+} from "@/utils/type";
 import ModalComponent, { type TypeProps } from "@/components/Modal.vue";
 
 const $store = useMainStore();
 
 const { versionInfo, versionAllTheme } = storeToRefs($store);
 
-const defaultColor = ref<DefauleColor>();
+const defaultColor = ref<DefauleColor | V2DefauleColor>();
 
-const mainColor = ref<Color>();
+const mainColor = ref<Color | V2Color>();
 
 const $message = useMessage();
 

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,4 +1,10 @@
-import type { VersionInfo, DefauleColor, Color } from "./type";
+import type {
+  VersionInfo,
+  DefauleColor,
+  Color,
+  V2DefauleColor,
+  V2Color,
+} from "./type";
 
 export const VANT_THEME_APP_VERSION = "VANT_THEME_APP_VERSION";
 
@@ -62,13 +68,13 @@ export const APP_HEADER_LANGUAGE = [
   },
 ];
 
-export const V2_DEFAULT_COLOR: DefauleColor = {
-  "--van-red": "#ee0a24",
-  "--van-blue": "#1989fa",
-  "--van-orange": "#ff976a",
-  "--van-orange-dark": "#ed6a0c",
-  "--van-orange-light": "#fffbe8",
-  "--van-green": "#07c160",
+export const V2_DEFAULT_COLOR: V2DefauleColor = {
+  "@red": "#ee0a24",
+  "@blue": "#1989fa",
+  "@orange": "#ff976a",
+  "@orange-dark": "#ed6a0c",
+  "@orange-light": "#fffbe8",
+  "@green": "#07c160",
 };
 
 export const V3_DEFAULT_COLOR: DefauleColor = {
@@ -89,7 +95,7 @@ export const V4_DEFAULT_COLOR: DefauleColor = {
   "--van-green": "#07c160",
 };
 
-export const V2_MAIN_COLOR: Color = "--van-red";
+export const V2_MAIN_COLOR: V2Color = "@red";
 
 export const V3_MAIN_COLOR: Color = "--van-red";
 

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -89,6 +89,17 @@ export type Color =
   | "--van-orange-light"
   | "--van-green";
 
+export type V2Color =
+  | "@red"
+  | "@blue"
+  | "@orange"
+  | "@orange-dark"
+  | "@orange-light"
+  | "@green";
+
 export type DefauleColor = {
   [keyof in Color]: string;
+};
+export type V2DefauleColor = {
+  [keyof in V2Color]: string;
 };


### PR DESCRIPTION
修复theme vant2创建主题修改之后，在theme list不能同步更新修改的基础变量值问题。theme vant2 版本全局变量覆盖方式和v3v4不同，使用同一套方式导致。望合并修复。